### PR TITLE
Adding multi-target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 Simple randomizer package to use with .NET projects. Sample usage included in the console application.
 
 # NuGet usage: Install-Package SimpleRandomizer
+
+# Supported .NET Versions
+
+ - .NET Framework 3.5
+ - .NET Framework 4.0
+ - .NET Framework 4.5
+ - .NET Framework 4.6
+ - .NET Standard 2.0 (includes .NET Framework 4.8+, .NET Core 1+, .NET 5+)

--- a/SimpleRandomizer.Console/App.config
+++ b/SimpleRandomizer.Console/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
-    </startup>
+        
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup>
 </configuration>

--- a/SimpleRandomizer.Console/Program.cs
+++ b/SimpleRandomizer.Console/Program.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using SimpleRandomizer;
 
 namespace SimpleRandomizer.ConsoleApp

--- a/SimpleRandomizer.Console/SimpleRandomizer.Console.csproj
+++ b/SimpleRandomizer.Console/SimpleRandomizer.Console.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SimpleRandomizer.Console</RootNamespace>
     <AssemblyName>SimpleRandomizer.Console</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -22,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -50,8 +53,8 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SimpleRandomizer\SimpleRandomizer.csproj">
-      <Project>{84a23fd6-b11c-4c57-9f48-bcf180788023}</Project>
+    <ProjectReference Include="..\SimpleRandomizer_netstandard20\SimpleRandomizer.csproj">
+      <Project>{2eec1ad7-f770-41e8-ae4c-3c5fad63714c}</Project>
       <Name>SimpleRandomizer</Name>
     </ProjectReference>
   </ItemGroup>

--- a/SimpleRandomizer.sln
+++ b/SimpleRandomizer.sln
@@ -1,16 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30523.141
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleRandomizer.Console", "SimpleRandomizer.Console\SimpleRandomizer.Console.csproj", "{81D4B312-D6F3-43F6-B083-7699031077B5}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleRandomizer", "SimpleRandomizer\SimpleRandomizer.csproj", "{84A23FD6-B11C-4C57-9F48-BCF180788023}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6F3B9628-21DA-466A-9D73-6DD458320AF5}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleRandomizer", "SimpleRandomizer_netstandard20\SimpleRandomizer.csproj", "{2EEC1AD7-F770-41E8-AE4C-3C5FAD63714C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,10 +22,10 @@ Global
 		{81D4B312-D6F3-43F6-B083-7699031077B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81D4B312-D6F3-43F6-B083-7699031077B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81D4B312-D6F3-43F6-B083-7699031077B5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{84A23FD6-B11C-4C57-9F48-BCF180788023}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{84A23FD6-B11C-4C57-9F48-BCF180788023}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{84A23FD6-B11C-4C57-9F48-BCF180788023}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{84A23FD6-B11C-4C57-9F48-BCF180788023}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EEC1AD7-F770-41E8-AE4C-3C5FAD63714C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EEC1AD7-F770-41E8-AE4C-3C5FAD63714C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EEC1AD7-F770-41E8-AE4C-3C5FAD63714C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EEC1AD7-F770-41E8-AE4C-3C5FAD63714C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SimpleRandomizer_netstandard20/Randomizer.cs
+++ b/SimpleRandomizer_netstandard20/Randomizer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SimpleRandomizer
+{
+    public class Randomizer
+    {
+        public static int PickRandomEntryIndex<T>(IList<T> rangeToPickFrom)
+        {
+            Random random = new Random();
+
+            return random.Next(rangeToPickFrom.Count());
+        }
+
+        public static T PickRandomEntry<T>(IList<T> rangeToPickFrom)
+        {
+            return rangeToPickFrom[PickRandomEntryIndex(rangeToPickFrom)];
+        }
+    }
+}

--- a/SimpleRandomizer_netstandard20/SimpleRandomizer.csproj
+++ b/SimpleRandomizer_netstandard20/SimpleRandomizer.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net35;net40;net45;net46;netstandard2.0;</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Adding support for: 
 - .NET Framework 3.5
 - .NET Framework 4.0
 - .NET Framework 4.5
 - .NET Framework 4.6
 - .NET Standard 2.0 (includes .NET Framework 4.8+, .NET Core 1+, .NET 5+)